### PR TITLE
MERGE feature/1-lock-promptengineers-version INTO lambda-loader

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-promptengineers[retrieval]
+promptengineers[retrieval]==0.0.23
 pymongo
 cryptography==37.0.4
 cffi


### PR DESCRIPTION
Locks the promptengineers[retrieval] version in requirements.txt to 0.0.23.

Closes #1